### PR TITLE
Bug with acquiring Unixtime in geolocation.js

### DIFF
--- a/www/js/geolocation.js
+++ b/www/js/geolocation.js
@@ -50,7 +50,7 @@ function Position() {
 
 Position.cast = function( p_coords, p_timestamp ) {
     // The timestamp is optional and can be auto-generated on creation
-    if( typeof p_timestamp == "undefined" ) p_timestamp = (new Date()).getMilliseconds();
+    if( typeof p_timestamp == "undefined" ) p_timestamp = (new Date()).getTime();
 
     var position = new Position();
 
@@ -122,7 +122,7 @@ Geolocation.prototype.getCurrentPosition = function( successCallback, errorCallb
     if( typeof options.enableHighAccuracy != "undefined" ) positionOptions.enableHighAccuracy = options.enableHighAccuracy;
 
     // Check if the cached object is sufficient
-    if( this.cachedPosition !== null && this.cachedPosition.timestamp > ((new Date()).getMilliseconds() - positionOptions.maximumAge) ) {
+    if( this.cachedPosition !== null && this.cachedPosition.timestamp > ((new Date()).getTime() - positionOptions.maximumAge) ) {
         successCallback( this.cachedPosition );
         return;
     }


### PR DESCRIPTION
In geolocation.js: 53, 125
http://www.w3schools.com/jsref/jsref_getmilliseconds.asp
getMilliseconds() returns a Number, from 0 to 999, representing milliseconds

In geolocation.cpp: 66
http://doc.trolltech.com/4.7-snapshot/qdatetime.html#toMSecsSinceEpoch
QDateTime::toMSecsSinceEpoch() returns the datetime as the number of milliseconds that have passed since 1970-01-01T00:00:00.000, Coordinated Universal Time (Qt::UTC).
